### PR TITLE
Update to okhttp 3.0.1 and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to `downloader`.
 
 ```java
 OkHttpClient client = // ...
-Picasso picasso = new Picasso.Builder()
+Picasso picasso = new Picasso.Builder(context)
     .downloader(new OkHttp3Downloader(client))
     .build()
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.jakewharton.picasso</groupId>
   <artifactId>picasso2-okhttp3-downloader</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.3-SNAPSHOT</version>
 
   <name>Picasso 2 OkHttp 3 Client</name>
   <description>A OkHttp 3 client implementation for Picasso 2.</description>
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.0.0-RC1</version>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.android</groupId>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>3.0.0-RC1</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.jakewharton.picasso</groupId>
   <artifactId>picasso2-okhttp3-downloader</artifactId>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
 
   <name>Picasso 2 OkHttp 3 Client</name>
   <description>A OkHttp 3 client implementation for Picasso 2.</description>


### PR DESCRIPTION
dependencies have been updated in the pom.xml file.
Also included the context object for the Picasso builder in the docs